### PR TITLE
FD-1758 & FD-1679 -- Ontology Sorting and Dividers in Mapping Modals

### DIFF
--- a/src/components/Manager/MappingsFunctions/MappingSearch.jsx
+++ b/src/components/Manager/MappingsFunctions/MappingSearch.jsx
@@ -407,7 +407,7 @@ export const MappingSearch = ({
                         >
                           {mappingsForSearch?.length > 0 && (
                             <Checkbox.Group
-                              className="mappings_checkbox"
+                              className="mappings_checkbox existing_display"
                               options={mappingsForSearch?.map((d, index) => {
                                 return {
                                   value: JSON.stringify({
@@ -429,7 +429,6 @@ export const MappingSearch = ({
                             valuePropName="value"
                             rules={[{ required: false }]}
                           >
-                            {' '}
                             <div className="modal_display_results">
                               {displaySelectedMappings?.map((sm, i) => (
                                 <Checkbox

--- a/src/components/Manager/MappingsFunctions/MappingsFunctions.scss
+++ b/src/components/Manager/MappingsFunctions/MappingsFunctions.scss
@@ -127,3 +127,7 @@
 .api_onto_search_bar {
   width: 400px;
 }
+
+.existing_display {
+  border-bottom: solid 1px #eeee;
+}

--- a/src/components/Manager/MappingsFunctions/OntologyCheckboxes.jsx
+++ b/src/components/Manager/MappingsFunctions/OntologyCheckboxes.jsx
@@ -112,8 +112,20 @@ export const OntologyCheckboxes = ({ preferenceType }) => {
         <div className="modal_display_results">
           {getFilteredItems(searchText)
             ?.sort((a, b) => {
-              const aValue = Object.values(a)[0];
-              const bValue = Object.values(b)[0];
+              const aKey = Object.keys(a)[0]; // gets the key from the first object in array
+              const bKey = Object.keys(b)[0]; // gets the key from the second object in array
+              const aValue = a[aKey]; // gets the value from the first key
+              const bValue = b[bKey]; // gets the value from the second key
+
+              // checks if one or both keys are in apiPreferencesCode
+              const aInPreferences = apiPreferencesCode?.includes(aKey);
+              const bInPreferences = apiPreferencesCode?.includes(bKey);
+
+              // If one of them is in apiPreferencesCode and the other isn't, prioritizes the one in apiPreferencesCode
+              if (aInPreferences && !bInPreferences) return -1; // if a is in apiPreferencesCode, it comes before b
+              if (!aInPreferences && bInPreferences) return 1; //if b is in apiPreferencesCode, it comes before a
+
+              // If both are in apiPreferencesCode or both are not, sorts by value
               return bValue - aValue;
             })
             .map((fc, i) => {

--- a/src/components/Projects/Tables/TableDetails.jsx
+++ b/src/components/Projects/Tables/TableDetails.jsx
@@ -9,6 +9,7 @@ import {
   Card,
   Col,
   Form,
+  message,
   notification,
   Row,
   Table,
@@ -93,7 +94,7 @@ export const TableDetails = () => {
         setMapping(data.codes);
         setEditMappings(null);
         form.resetFields();
-        notification.success({ description: 'Mapping removed.' });
+        message.success('Mapping removed.');
       })
       .catch(error => {
         console.log(error, 'error');
@@ -107,19 +108,6 @@ export const TableDetails = () => {
         return error;
       })
       .finally(() => setLoading(false));
-  };
-
-  const alphabetizeOntologies = ontologies => {
-    // Sort the keys alphabetically
-    const sortedKeys = Object.keys(ontologies).sort();
-
-    // Rebuild object using the sorted keys
-    const sortedOntologies = {};
-    sortedKeys.forEach(key => {
-      sortedOntologies[key] = ontologies[key];
-    });
-
-    return sortedOntologies;
   };
 
   // fetches the table and sets 'table' to the response

--- a/src/components/Projects/Terminologies/Terminology.jsx
+++ b/src/components/Projects/Terminologies/Terminology.jsx
@@ -4,7 +4,16 @@ import { myContext } from '../../../App';
 import './Terminology.scss';
 import { Spinner } from '../../Manager/Spinner';
 import { getById } from '../../Manager/FetchManager';
-import { Button, Col, Form, notification, Row, Table, Tooltip } from 'antd';
+import {
+  Button,
+  Col,
+  Form,
+  message,
+  notification,
+  Row,
+  Table,
+  Tooltip,
+} from 'antd';
 import { CloseCircleOutlined } from '@ant-design/icons';
 import { EditMappingsModal } from './EditMappingModal';
 import { EditTerminologyDetails } from './EditTerminologyDetails';
@@ -88,7 +97,7 @@ export const Terminology = () => {
         setMapping(data.codes);
         setEditMappings(null);
         form.resetFields();
-        notification.success({ description: 'Mapping removed.' });
+        message.success('Mapping removed.');
       })
       .catch(error => {
         console.log(error, 'error');

--- a/src/components/Projects/Terminologies/Terminology.scss
+++ b/src/components/Projects/Terminologies/Terminology.scss
@@ -101,6 +101,7 @@
 .modal_display_results {
   display: flex;
   flex-direction: column;
+  border-bottom: solid 1px #eeee;
 }
 .modal_display_result {
   margin: 0 0 10px 0;


### PR DESCRIPTION
Preferred ontologies are now sorted to the top of the page regardless of number of results. 
Subtle, solid line dividers added to mapping modals to separate existing, selected, and available mappings.

When getting new mappings:
![Screenshot 2024-11-05 200610](https://github.com/user-attachments/assets/b74c01d1-98e4-4f01-b00e-fce6a37a8e51)

When editing mappings:
![Screenshot 2024-11-05 200833](https://github.com/user-attachments/assets/8c29a3ec-c2d6-45b1-a0ed-d4d8be17a989)

When resetting mappings:
![Screenshot 2024-11-05 201011](https://github.com/user-attachments/assets/cd744e8a-c03e-4857-877d-da9fbbf78238)
