### PR TITLE
FD-1680 -- Preferred Terminology Filtering by Name and System

### DIFF
--- a/src/components/Projects/Tables/EditDataTypeSubForm.jsx
+++ b/src/components/Projects/Tables/EditDataTypeSubForm.jsx
@@ -57,13 +57,16 @@ function EditDataTypeSubForm({ type, form, editRow, tableData }) {
               }}
               placeholder="Search to Select"
               optionFilterProp="children"
-              filterOption={(input, option) =>
-                (option?.label ?? '').includes(input)
-              }
+              // Searches by terminology name, accounting for spaces in the name
+              filterOption={(input, option) => {
+                const trimmedInput = input.toLowerCase().trim();
+                const optionLabel = (option?.label).toLowerCase().trim();
+                return optionLabel.includes(trimmedInput);
+              }}
               filterSort={(optionA, optionB) =>
-                (optionA?.label ?? '')
+                (optionA?.label)
                   .toLowerCase()
-                  .localeCompare((optionB?.label ?? '').toLowerCase())
+                  .localeCompare((optionB?.label).toLowerCase())
               }
               options={terminologies.map(term => {
                 return {

--- a/src/components/Projects/Terminologies/PreferredTerminology.jsx
+++ b/src/components/Projects/Terminologies/PreferredTerminology.jsx
@@ -144,14 +144,17 @@ export const PreferredTerminology = ({ terminology, setTerminology }) => {
     setPreferredData([]);
   };
 
-  // Filters the terminologies that have already been selected out of the main terminology array to avoid duplicates
+  // Filters terminologies that have already been selected (by combination of name and url) out of the main terminology array to avoid duplicates
   const filterTerminologies = () => {
     const terminologiesToExclude = new Set([
-      ...prefTerminologies?.map(pt => pt?.id),
-      ...displaySelectedTerminologies?.map(dst => dst?.id),
-      ...preferredData?.map(ep => ep?.id),
+      ...prefTerminologies?.map(pt => `${pt?.name}|${pt?.url}`),
+      ...displaySelectedTerminologies?.map(dst => `${dst?.name}|${dst?.url}`),
+      ...preferredData?.map(ep => `${ep?.name}|${ep?.url}`),
     ]);
-    return terminologies.filter(t => !terminologiesToExclude?.has(t.id));
+
+    return terminologies.filter(
+      t => !terminologiesToExclude.has(`${t?.name}|${t?.url}`)
+    );
   };
 
   const filteredTerminologyArray = filterTerminologies();


### PR DESCRIPTION
Preferred terminology selection to use both name and system to filter out selected terminologies. If a selected terminology has the same name and system, it is no longer displayed in the list of available terminologies.

https://github.com/user-attachments/assets/d73f78ec-9ee8-44e0-9bc6-45f2c6404588

