### PR TITLE
Quick starting point for Map Dragon Help Site

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,45 @@
+# Map Dragon
+This application will support several user groups in submitting and validating their data, managing and tracking data definitions, and aligning data to standardized terms. 
+
+## Getting Started
+### Vite React App
+
+This is a React application bootstrapped with Vite. 
+
+### Prerequisites
+
+Make sure you have Node.js and npm installed on your machine.
+
+### Installation
+
+1. Clone the repository:
+
+   ```sh
+   git clone git@github.com:NIH-NCPI/map-dragon.git
+
+2. Navigate into the project directory:
+
+   ```sh
+   cd map-dragon
+3. Install dependencies
+
+   ```sh
+   npm i
+
+### Development
+1. To start the development server, run:
+   ```sh
+   npm run dev
+
+### Dependencies
+This project utilizes the following dependencies:
+
++ React: A JavaScript library for building user interfaces  
++ Vite: A front-end tooling for web development  
++ Ant Design: A design component library
++ Sass: A CSS preprocessor
++ React OAuth2 | Google: A React library for Google OAuth
++ jwt-decode: A JWT decoder
++ Papa Parse: A CSV parser
+
+

--- a/docs/_navbar.md
+++ b/docs/_navbar.md
@@ -1,0 +1,4 @@
+* Map Dragon
+  * [Map Dragon Local Installation Directions](https://github.com/NIH-NCPI/map-dragon)
+* File Formats
+  * [Loading a Data Dictionary](datadictionary.md)

--- a/docs/datadictionary.md
+++ b/docs/datadictionary.md
@@ -1,0 +1,31 @@
+# Loading a Data Dictionary
+(TBD How to use the website to load the DD)
+
+## Expected Format for DD Table
+The following table format is currently the only format accepted by the Map Dragon "Load Table" function. When run, a new data dictionary table is instantiated along with relevant enumerations as new terminologies.
+
+Fields such as *variable_name* and *data_type* are required. Other fields such as *description* are optional but highly recommended. 
+
+The data should be a valid, ASCII only CSV file with double quotes used for "Quote Characters", commas for delimiters, etc. 
+
+| *Column Name* | *Column Descriptions* | *Column Type* |
+|  ------------ | --------------------- | ------------- |
+| *variable_name* | The human readable name associated with variable name | String |
+| *description* | Fully informative description of the contents associated with this variable/column| String |
+| *data_type* | Data type associated with column data  | integer, number, string, enumeration |
+| *min* | Minimum value (integers and numbers only) | numeric value |
+| *max* | Maximum acceptable value (integers and numbers only) | numeric value | 
+| *units* | UCUM code for units | UCUM code prefixed with the curie, UCUM. UCUM:ml for example |
+| *enumerations* | Semi-colon separated list of enumerated values. See below for more details about formatting the enumeration list. | String |
+
+### Formatting for Enumerations
+At the top level, enumerations are just a list of terms separated by semi-colons. For enumerated types with specified codes, these will be provided in the following format: 
+
+> 1=Male;2=Female;0=Unknown;-1=Preferred Not To Answer
+
+In this example, the following codes are extracted: 1, 2, 0 and -1 and assigned the following displays (in order): Male, Female, Unknown and Preferred Not To Answer.
+
+If there is no code specified, the codes will be created using the following logic: 
+> Case is dropped to lower case and potentially problematic characters, such as parenthesis, "(" or ")" will be removed. Whitespace characters will be replaced with underscores, "_". 
+
+There is currently no way to allow codes or values to include semi-colons, ";", or equal signs, "=" in them. They should be replaced prior to loading into Map Dragon. 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Document</title>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+  <meta name="description" content="Description">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
+  <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify/themes/dark.css" />
+</head>
+<body>
+  <div id="app"></div>
+  <script>
+    window.$docsify = {
+      name: 'Map Dragon',
+      repo: 'https://github.com/NIH-NCPI/map-dragon',
+      loadNavbar: true
+    }
+  </script>
+  <!-- Docsify v4 -->
+  <script src="//cdn.jsdelivr.net/npm/docsify@4"></script>
+</body>
+</html>


### PR DESCRIPTION
This is just an easy way to create a reasonably attractive help site. Maybe we can link that help button the github.io pages once we merge this and then update the repo to publish the docs page as the documentation website. 