### PR TITLE
FD-2709 - Fixing 'View More' Results Display

### DIFF
--- a/src/Contexts/SearchContext.jsx
+++ b/src/Contexts/SearchContext.jsx
@@ -1,4 +1,4 @@
-import { createContext,useContext,useEffect, useState } from 'react';
+import { createContext, useContext, useEffect, useState } from 'react';
 import { myContext } from '../App';
 import { Outlet } from 'react-router-dom';
 import { getDefaultOntologies } from '../components/Manager/FetchManager';
@@ -24,14 +24,19 @@ export function SearchContextRoot() {
   const [moreAvailable, setMoreAvailable] = useState(false);
   const [resultsCount, setResultsCount] = useState();
   const [selectedApi, setSelectedApi] = useState('');
-  const {vocabUrl} = useContext(myContext);
+  const { vocabUrl } = useContext(myContext);
   const [defaultOntologies, setDefaultOntologies] = useState([]);
+  const [page, setPage] = useState(0);
   const entriesPerPage = 100;
   useEffect(() => {
     const fetchDefaultOntologiesData = async () => {
       try {
         const result = await getDefaultOntologies(vocabUrl);
-        setDefaultOntologies(result["Application Default"].api_preference.ols.map(str=>str.toUpperCase())); // Update state with fetched data
+        setDefaultOntologies(
+          result['Application Default'].api_preference.ols.map(str =>
+            str.toUpperCase()
+          )
+        ); // Update state with fetched data
       } catch (error) {
         console.error('Error fetching default ontologies:', error);
       }
@@ -39,7 +44,7 @@ export function SearchContextRoot() {
 
     fetchDefaultOntologiesData();
   }, [vocabUrl]);
-  
+
   const preferenceTypeSet = data =>
     apiPreferencesTerm ? setApiPreferencesTerm(data) : setApiPreferences(data);
 
@@ -95,6 +100,8 @@ export function SearchContextRoot() {
     defaultOntologies,
     selectedApi,
     setSelectedApi,
+    page,
+    setPage,
   };
 
   return (

--- a/src/components/Manager/MappingsFunctions/AssignMappingsCheckboxes.jsx
+++ b/src/components/Manager/MappingsFunctions/AssignMappingsCheckboxes.jsx
@@ -38,9 +38,10 @@ export const AssignMappingsCheckboxes = ({
     setSelectedApi,
     preferenceType,
     prefTypeKey,
+    page,
+    setPage,
   } = useContext(SearchContext);
 
-  const [page, setPage] = useState(0);
   const [loading, setLoading] = useState(true);
   const [loadingResults, setLoadingResults] = useState(false);
   const [results, setResults] = useState([]);

--- a/src/components/Manager/MappingsFunctions/GetMappingsModal.jsx
+++ b/src/components/Manager/MappingsFunctions/GetMappingsModal.jsx
@@ -46,8 +46,9 @@ export const GetMappingsModal = ({
     resultsCount,
     selectedApi,
     setSelectedApi,
+    page,
+    setPage,
   } = useContext(SearchContext);
-  const [page, setPage] = useState(0);
   const [loading, setLoading] = useState(true);
   const [loadingResults, setLoadingResults] = useState(false);
   const [results, setResults] = useState([]);

--- a/src/components/Manager/MappingsFunctions/MappingSearch.jsx
+++ b/src/components/Manager/MappingsFunctions/MappingSearch.jsx
@@ -43,9 +43,10 @@ export const MappingSearch = ({
     setResultsCount,
     selectedApi,
     setSelectedApi,
+    page,
+    setPage,
   } = useContext(SearchContext);
   const { tableId } = useParams();
-  const [page, setPage] = useState(0);
   const [loading, setLoading] = useState(true);
   const [results, setResults] = useState([]);
   const [lastCount, setLastCount] = useState(0); //save last count as count of the results before you fetch data again

--- a/src/components/Manager/MappingsFunctions/OntologyCheckboxes.jsx
+++ b/src/components/Manager/MappingsFunctions/OntologyCheckboxes.jsx
@@ -18,7 +18,8 @@ export const OntologyCheckboxes = ({ preferenceType }) => {
     unformattedPref,
     selectedApi,
     setSelectedApi,
-    defaultOntologies
+    defaultOntologies,
+    setPage,
   } = useContext(SearchContext);
   const { Search } = Input;
 
@@ -37,7 +38,8 @@ export const OntologyCheckboxes = ({ preferenceType }) => {
 
   const [searchText, setSearchText] = useState('');
 
-   const selectedOntologies = selectedApi === 'ols' ? defaultOntologies : ['SNOMEDCT_US'];
+  const selectedOntologies =
+    selectedApi === 'ols' ? defaultOntologies : ['SNOMEDCT_US'];
 
   //If there are no preferences set for an API, it sets them to default ontologies
   if (
@@ -115,7 +117,7 @@ export const OntologyCheckboxes = ({ preferenceType }) => {
 
   const onCheckboxChange = e => {
     const { value, checked } = e.target;
-
+    setPage(0);
     setCheckedOntologies(prevCheckedOntologies => {
       // If checked, adds the value to checkedOntologies, otherwise filters out the ones not checked
       const updatedCheckedOntologies = checked
@@ -213,7 +215,10 @@ export const OntologyCheckboxes = ({ preferenceType }) => {
         buttonStyle="solid"
         options={options}
         defaultValue={options[0].value}
-        onChange={e => setSelectedApi(e.target.value)}
+        onChange={e => {
+          setPage(0);
+          setSelectedApi(e.target.value);
+        }}
       />
       <Search
         placeholder="Ontologies"

--- a/src/components/Projects/Tables/TableDetails.jsx
+++ b/src/components/Projects/Tables/TableDetails.jsx
@@ -104,13 +104,18 @@ export const TableDetails = () => {
       editor: user.email,
     };
 
-    fetch(`${vocabUrl}/Table/${tableId}/mapping/${uriEncoded(mappingCode)}`, {
-      method: 'PUT',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(mappingsDTO),
-    })
+    fetch(
+      `${vocabUrl}/Table/${tableId}/mapping/${uriEncoded(
+        mappingCode
+      )}?user_input=true&user=${user?.email}`,
+      {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(mappingsDTO),
+      }
+    )
       .then(res => {
         if (res.ok) {
           return res.json();

--- a/src/components/Search/SearchResults.jsx
+++ b/src/components/Search/SearchResults.jsx
@@ -6,9 +6,6 @@ import './SearchResults.scss';
 import { SearchSpinner } from '../Manager/Spinner';
 import { SearchContext } from '../../Contexts/SearchContext';
 
-
-
-
 export const SearchResults = () => {
   const [buttonDisabled, setButtonDisabled] = useState(true);
   const {
@@ -17,12 +14,12 @@ export const SearchResults = () => {
     setMoreAvailable,
     resultsCount,
     setResultsCount,
-    defaultOntologies
-
+    defaultOntologies,
+    page,
+    setPage,
   } = useContext(SearchContext);
   const { results, setResults, vocabUrl } = useContext(myContext);
 
-  const [page, setPage] = useState(0); //page number for search results pagination
   const [loading, setLoading] = useState(true);
   const [lastCount, setLastCount] = useState(0); //save last count as count of the results before you fetch data again
 
@@ -124,8 +121,9 @@ The user is then redirected to the search page, which completes the search for t
 
             <div>
               <button
-                className={`search_button_results ${buttonDisabled ? 'disabled_results' : ''
-                  }`}
+                className={`search_button_results ${
+                  buttonDisabled ? 'disabled_results' : ''
+                }`}
                 onClick={e => {
                   /* if the input field has a value (i.e. term being searched):
                  the page of search results is set to 1 to fetch the results of the first page


### PR DESCRIPTION
When the user clicks the "View More" pagination link and changes the ontology filters, the results are displayed in a new search and the scrollbar returns to the top.


https://github.com/user-attachments/assets/4c51c787-d4e4-456e-aa5e-0fa5e4337f4c


