### PR TITLE
FD-2621, FD-2710, FD-1790 - Bug Fixes and Footer Content

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -36,6 +36,7 @@ function App() {
   const [user, setUser] = useState(null);
   const [ontologyForPagination, setOntologyForPagination] = useState([]);
   const [ucumCodes, setUcumCodes] = useState([]);
+  const [version, setVersion] = useState({});
 
   message.config({
     top: '25vh',
@@ -79,6 +80,8 @@ function App() {
           setOntologyForPagination,
           ucumCodes,
           setUcumCodes,
+          version,
+          setVersion,
         }}
       >
         <AppRouter />

--- a/src/components/About/About.jsx
+++ b/src/components/About/About.jsx
@@ -1,32 +1,14 @@
 import { useContext, useEffect, useState } from 'react';
-import { Descriptions, notification, Spin } from 'antd';
-import { getAll } from '../Manager/FetchManager';
+import { Descriptions } from 'antd';
 import { myContext } from '../../App';
-import { useNavigate } from 'react-router-dom';
-import { Spinner } from '../Manager/Spinner';
 import './About.scss';
 
 export const About = () => {
-  const { vocabUrl, mapDragonVersion } = useContext(myContext);
-  const navigate = useNavigate();
+  const { mapDragonVersion, version } = useContext(myContext);
   const [loading, setLoading] = useState(true);
-  const [version, setVersion] = useState({});
 
   useEffect(() => {
     document.title = 'About - Map Dragon';
-    setLoading(true);
-    getAll(vocabUrl, 'version', navigate)
-      .then(data => setVersion(data))
-      .catch(error => {
-        if (error) {
-          notification.error({
-            message: 'Error',
-            description: 'An error occurred.',
-          });
-        }
-        return error;
-      })
-      .finally(() => setLoading(false));
   }, []);
 
   const items = [
@@ -51,16 +33,12 @@ export const About = () => {
 
   return (
     <>
-      {loading ? (
-        <Spinner />
-      ) : (
-        <div className="about_container">
-          <h2>About</h2>
-          <div className="about_description">
-            <Descriptions title="Version" bordered column={1} items={items} />
-          </div>
+      <div className="about_container">
+        <h2>About</h2>
+        <div className="about_description">
+          <Descriptions title="Version" bordered column={1} items={items} />
         </div>
-      )}
+      </div>
     </>
   );
 };

--- a/src/components/Manager/MappingsFunctions/AssignMappingsCheckboxes.jsx
+++ b/src/components/Manager/MappingsFunctions/AssignMappingsCheckboxes.jsx
@@ -145,13 +145,13 @@ export const AssignMappingsCheckboxes = ({
   }, [mappingProp]);
 
   useEffect(() => {
-    if (apiPreferencesCode !== undefined) {
+    if (apiPreferencesCode !== undefined && active === 'search') {
       fetchResults(0, mappingProp);
     }
   }, [mappingProp]);
 
   useEffect(() => {
-    if (apiPreferencesCode !== undefined) {
+    if (apiPreferencesCode !== undefined && active === 'search') {
       fetchResults(page, currentSearchProp);
     }
   }, [page, selectedApi]);
@@ -186,7 +186,8 @@ export const AssignMappingsCheckboxes = ({
     } else if (
       prefTerminologies.length === 0 &&
       !!currentSearchProp &&
-      apiPreferencesCode !== undefined
+      apiPreferencesCode !== undefined &&
+      active === 'search'
     ) {
       fetchResults(page, currentSearchProp);
     }
@@ -350,6 +351,7 @@ export const AssignMappingsCheckboxes = ({
               <div>
                 <b>{d?.display}</b>
               </div>
+              <div className="api_ontology_prefix">{d?.ontology_prefix}</div>
               <div>
                 <a href={d?.code_iri} target="_blank">
                   {d?.code}

--- a/src/components/Nav/Footer.jsx
+++ b/src/components/Nav/Footer.jsx
@@ -1,5 +1,37 @@
+import { notification } from 'antd';
+import { useContext, useEffect } from 'react';
 import './NavBar.scss';
+import { myContext } from '../../App';
+import { getAll } from '../Manager/FetchManager';
 
 export const Footer = () => {
-  return <footer className="footer"></footer>;
+  const { version, setVersion, mapDragonVersion, vocabUrl } =
+    useContext(myContext);
+
+  useEffect(() => {
+    getAll(vocabUrl, 'version', null)
+      .then(data => setVersion(data))
+      .catch(error => {
+        if (error) {
+          notification.error({
+            message: 'Error',
+            description: 'An error occurred loading the version.',
+          });
+        }
+        return error;
+      });
+  }, []);
+
+  return (
+    <footer className="footer">
+      <div className="footer_content_wrapper">
+        <div className="footer_content">
+          Locutus version: {version?.version}
+        </div>
+        <div className="footer_content">
+          Map Dragon version: {mapDragonVersion}
+        </div>
+      </div>
+    </footer>
+  );
 };

--- a/src/components/Nav/NavBar.scss
+++ b/src/components/Nav/NavBar.scss
@@ -130,4 +130,19 @@ footer {
   width: 100%;
   height: 50px;
   background-color: $navColor;
+  display: flex;
+  justify-content: center;
+}
+
+.footer_content_wrapper {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 20px;
+  margin: 0 0 0 20px;
+}
+
+.footer_content {
+  font-size: 0.8rem;
+  color: #eeee;
 }

--- a/src/components/Projects/Tables/TableMenu.jsx
+++ b/src/components/Projects/Tables/TableMenu.jsx
@@ -138,12 +138,13 @@ export const TableMenu = ({
     },
   ];
 
+  // If mappings exist for a variable, it adds the "Mappings" label to the menu
   const mappingsMenuLabel = {
     key: `${tableData.key}-3`,
     label: 'Mappings',
   };
 
-  showEditMappings && items.splice(2, 0, mappingsMenuLabel);
+  showEditMappings && items[0]?.children?.splice(2, 0, mappingsMenuLabel);
 
   // onClick function for Menu.
   // If a user is not logged in, the login screen is triggered

--- a/src/components/Projects/Tables/TableMenu.jsx
+++ b/src/components/Projects/Tables/TableMenu.jsx
@@ -131,16 +131,19 @@ export const TableMenu = ({
         { key: `${tableData.key}-1`, label: 'Edit' },
         { key: `${tableData.key}-2`, label: 'Delete' },
         {
-          key: `${tableData.key}-3`,
-          label: showEditMappings ? 'Mappings' : 'Get Mappings',
-        },
-        {
           key: `${tableData.key}-4`,
           label: 'History',
         },
       ],
     },
   ];
+
+  const mappingsMenuLabel = {
+    key: `${tableData.key}-3`,
+    label: 'Mappings',
+  };
+
+  showEditMappings && items.splice(2, 0, mappingsMenuLabel);
 
   // onClick function for Menu.
   // If a user is not logged in, the login screen is triggered

--- a/src/components/Projects/Tables/TableMenu.jsx
+++ b/src/components/Projects/Tables/TableMenu.jsx
@@ -157,15 +157,11 @@ export const TableMenu = ({
       case `${tableData.key}-2`:
         return user ? setDeleteRow(true) : loginDelete();
       case `${tableData.key}-3`:
-        return showEditMappings
-          ? // If mappings exist for a variable, sets editMappings to the variable and opens EditMappingsTableModal in turn
-            user
-            ? setEditMappings(variable)
-            : loginEditMappings()
-          : // If mappings do not exist for a variable, sets getMappings to the variable and opens GetMappingsModal in turn
-          user
-          ? setGetMappings(variable)
-          : loginGetMappings();
+        return (
+          showEditMappings && // If mappings exist for a variable, sets editMappings to the variable and opens EditMappingsTableModal
+          user &&
+          setEditMappings(variable)
+        );
       case `${tableData.key}-4`:
         return setShowHistory(tableData.key);
     }

--- a/src/components/Projects/Terminologies/TerminologyMenu.jsx
+++ b/src/components/Projects/Terminologies/TerminologyMenu.jsx
@@ -151,12 +151,13 @@ export const TerminologyMenu = ({
     },
   ];
 
+  // If mappings exist for a code, it adds the "Mappings" label to the menu
   const mappingsMenuLabel = {
     key: `${tableData.key}-3`,
     label: 'Mappings',
   };
 
-  showEditMappings && items.splice(2, 0, mappingsMenuLabel);
+  showEditMappings && items[0]?.children?.splice(2, 0, mappingsMenuLabel);
 
   // onClick function for Menu.
   // If a user is not logged in, the login screen is triggered

--- a/src/components/Projects/Terminologies/TerminologyMenu.jsx
+++ b/src/components/Projects/Terminologies/TerminologyMenu.jsx
@@ -144,21 +144,19 @@ export const TerminologyMenu = ({
         { key: `${tableData.key}-1`, label: 'Edit' },
         { key: `${tableData.key}-2`, label: 'Delete' },
         {
-          key: `${tableData.key}-3`,
-          label:
-            prefTerminologies?.length > 0 && !showEditMappings
-              ? 'Assign Mappings'
-              : showEditMappings
-              ? 'Mappings'
-              : 'Get Mappings',
-        },
-        {
           key: `${tableData.key}-4`,
           label: 'History',
         },
       ],
     },
   ];
+
+  const mappingsMenuLabel = {
+    key: `${tableData.key}-3`,
+    label: 'Mappings',
+  };
+
+  showEditMappings && items.splice(2, 0, mappingsMenuLabel);
 
   // onClick function for Menu.
   // If a user is not logged in, the login screen is triggered


### PR DESCRIPTION
- Removed "Assign Mappings" and "Get Mappings" from Table and Terminology menus
If a code does not have mappings, Assign Mappings or Get Mappings are no longer displayed in the menu:
![Screenshot 2025-04-24 145408](https://github.com/user-attachments/assets/11598ca6-7f7b-441e-936a-33c248aac25d)
If a code has mappings, "Mappings" is still displayed in the menu:
![Screenshot 2025-04-24 145433](https://github.com/user-attachments/assets/80875e92-92ec-4ac2-8434-14e65821402f)

- Corrected issue with AssignMappings making search API calls on render
- Added version information to footer
![Screenshot 2025-04-24 145731](https://github.com/user-attachments/assets/e4141a2b-9566-48e7-9d71-2b4e988207da)


